### PR TITLE
[4.3] com_contact in category_view -> Change the language-string for correct table-head-title

### DIFF
--- a/administrator/components/com_config/src/Controller/RequestController.php
+++ b/administrator/components/com_config/src/Controller/RequestController.php
@@ -65,14 +65,11 @@ class RequestController extends BaseController
 
         try {
             $data = $model->getData();
-            $user = $this->app->getIdentity();
         } catch (\Exception $e) {
             $this->app->enqueueMessage($e->getMessage(), 'error');
 
             return false;
         }
-
-        $this->userIsSuperAdmin = $user->authorise('core.admin');
 
         // Required data
         $requiredData = [

--- a/administrator/components/com_contact/forms/filter_contacts.xml
+++ b/administrator/components/com_contact/forms/filter_contacts.xml
@@ -107,8 +107,8 @@
 			<option value="a.featured DESC">JFEATURED_DESC</option>
 			<option value="a.published ASC">JSTATUS_ASC</option>
 			<option value="a.published DESC">JSTATUS_DESC</option>
-			<option value="a.name ASC">JGLOBAL_TITLE_ASC</option>
-			<option value="a.name DESC">JGLOBAL_TITLE_DESC</option>
+			<option value="a.name ASC">JGLOBAL_NAME_ASC</option>
+			<option value="a.name DESC">JGLOBAL_NAME_DESC</option>
 			<option value="category_title ASC">JCATEGORY_ASC</option>
 			<option value="category_title DESC">JCATEGORY_DESC</option>
 			<option value="ul.name ASC">COM_CONTACT_FIELD_LINKED_USER_LABEL_ASC</option>

--- a/administrator/components/com_contact/tmpl/contacts/default.php
+++ b/administrator/components/com_contact/tmpl/contacts/default.php
@@ -68,7 +68,7 @@ if ($saveOrder && !empty($this->items)) {
                                     <?php echo HTMLHelper::_('searchtools.sort', 'JSTATUS', 'a.published', $listDirn, $listOrder); ?>
                                 </th>
                                 <th scope="col">
-                                    <?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_TITLE', 'a.name', $listDirn, $listOrder); ?>
+                                    <?php echo HTMLHelper::_('searchtools.sort', 'COM_CONTACT_FIELD_NAME_LABEL', 'a.name', $listDirn, $listOrder); ?>
                                 </th>
                                 <th scope="col" class="w-10 d-none">
                                     <?php echo HTMLHelper::_('searchtools.sort', 'COM_CONTACT_FIELD_LINKED_USER_LABEL', 'ul.name', $listDirn, $listOrder); ?>

--- a/administrator/components/com_finder/src/Indexer/Language/Zh.php
+++ b/administrator/components/com_finder/src/Indexer/Language/Zh.php
@@ -11,7 +11,6 @@
 namespace Joomla\Component\Finder\Administrator\Indexer\Language;
 
 use Joomla\Component\Finder\Administrator\Indexer\Language;
-use Joomla\String\StringHelper;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -61,26 +60,11 @@ class Zh extends Language
      */
     public function tokenise($input)
     {
+        // We first add whitespace around each Chinese character, so that our later code can easily split on this.
+        $input = preg_replace('#\p{Han}#mui', ' $0 ', $input);
+
+        // Now we split up the input into individual terms
         $terms = parent::tokenise($input);
-
-        // Iterate through the terms and test if they contain Chinese.
-        for ($i = 0, $n = count($terms); $i < $n; $i++) {
-            $charMatches = [];
-            $charCount   = preg_match_all('#[\p{Han}]#mui', $terms[$i], $charMatches);
-
-            // Split apart any groups of Chinese characters.
-            for ($j = 0; $j < $charCount; $j++) {
-                $tSplit = StringHelper::str_ireplace($charMatches[0][$j], '', $terms[$i], false);
-
-                if (!empty($tSplit)) {
-                    $terms[$i] = $tSplit;
-                } else {
-                    unset($terms[$i]);
-                }
-
-                $terms[] = $charMatches[0][$j];
-            }
-        }
 
         return $terms;
     }

--- a/components/com_contact/forms/filter_contacts.xml
+++ b/components/com_contact/forms/filter_contacts.xml
@@ -98,8 +98,8 @@
 			<option value="a.published DESC">JSTATUS_DESC</option>
 			<option value="a.featured ASC">JFEATURED_ASC</option>
 			<option value="a.featured DESC">JFEATURED_DESC</option>
-			<option value="a.name ASC">JGLOBAL_TITLE_ASC</option>
-			<option value="a.name DESC">JGLOBAL_TITLE_DESC</option>
+			<option value="a.name ASC">JGLOBAL_NAME_ASC</option>
+			<option value="a.name DESC">JGLOBAL_NAME_DESC</option>
 			<option value="category_title ASC">JCATEGORY_ASC</option>
 			<option value="category_title DESC">JCATEGORY_DESC</option>
 			<option value="ul.name ASC">COM_CONTACT_FIELD_LINKED_USER_LABEL_ASC</option>

--- a/components/com_contact/tmpl/category/default_items.php
+++ b/components/com_contact/tmpl/category/default_items.php
@@ -88,7 +88,7 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
                 <thead<?php echo $this->params->get('show_headings', '1') ? '' : ' class="visually-hidden"'; ?>>
                     <tr>
                         <th scope="col" id="categorylist_header_title">
-                            <?php echo HTMLHelper::_('grid.sort', 'JGLOBAL_TITLE', 'a.name', $listDirn, $listOrder, null, 'asc', '', 'adminForm'); ?>
+                            <?php echo HTMLHelper::_('grid.sort', 'COM_CONTACT_CONTACT_EMAIL_NAME_LABEL', 'a.name', $listDirn, $listOrder, null, 'asc', '', 'adminForm'); ?>
                         </th>
                         <th scope="col">
                             <?php echo Text::_('COM_CONTACT_CONTACT_DETAILS'); ?>

--- a/components/com_content/tmpl/archive/default.php
+++ b/components/com_content/tmpl/archive/default.php
@@ -25,29 +25,35 @@ use Joomla\CMS\Router\Route;
 
 <form id="adminForm" action="<?php echo Route::_('index.php'); ?>" method="post" class="com-content-archive__form">
     <fieldset class="com-content-archive__filters filters">
-    <div class="filter-search form-inline">
-        <?php if ($this->params->get('filter_field') !== 'hide') : ?>
-        <div class="me-2">
-            <label class="filter-search-lbl visually-hidden" for="filter-search"><?php echo Text::_('COM_CONTENT_TITLE_FILTER_LABEL') . '&#160;'; ?></label>
-            <input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->filter); ?>" class="inputbox col-md-2" onchange="document.getElementById('adminForm').submit();" placeholder="<?php echo Text::_('COM_CONTENT_TITLE_FILTER_LABEL'); ?>">
+        <legend class="visually-hidden">
+            <?php echo Text::_('COM_CONTENT_FORM_FILTER_LEGEND'); ?>
+        </legend>
+        <div class="filter-search form-inline">
+            <?php if ($this->params->get('filter_field') !== 'hide') : ?>
+            <div class="mb-2">
+                <label class="filter-search-lbl visually-hidden" for="filter-search"><?php echo Text::_('COM_CONTENT_TITLE_FILTER_LABEL') . '&#160;'; ?></label>
+                <input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->filter); ?>" class="inputbox col-md-2" onchange="document.getElementById('adminForm').submit();" placeholder="<?php echo Text::_('COM_CONTENT_TITLE_FILTER_LABEL'); ?>">
+            </div>
+            <?php endif; ?>
+
+            <span class="me-2">
+                <label class="visually-hidden" for="month"><?php echo Text::_('JMONTH'); ?></label>
+                <?php echo $this->form->monthField; ?>
+            </span>
+            <span class="me-2">
+                <label class="visually-hidden" for="year"><?php echo Text::_('JYEAR'); ?></label>
+                <?php echo $this->form->yearField; ?>
+            </span>
+            <span class="me-2">
+                <label class="visually-hidden" for="limit"><?php echo Text::_('JGLOBAL_DISPLAY_NUM'); ?></label>
+                <?php echo $this->form->limitField; ?>
+            </span>
+
+            <button type="submit" class="btn btn-primary" style="vertical-align: top;"><?php echo Text::_('JGLOBAL_FILTER_BUTTON'); ?></button>
+            <input type="hidden" name="view" value="archive">
+            <input type="hidden" name="option" value="com_content">
+            <input type="hidden" name="limitstart" value="0">
         </div>
-        <?php endif; ?>
-
-        <span class="me-2">
-        <?php echo $this->form->monthField; ?>
-        </span>
-        <span class="me-2">
-        <?php echo $this->form->yearField; ?>
-        </span>
-        <span class="me-2">
-        <?php echo $this->form->limitField; ?>
-        </span>
-
-        <button type="submit" class="btn btn-primary" style="vertical-align: top;"><?php echo Text::_('JGLOBAL_FILTER_BUTTON'); ?></button>
-        <input type="hidden" name="view" value="archive">
-        <input type="hidden" name="option" value="com_content">
-        <input type="hidden" name="limitstart" value="0">
-    </div>
     </fieldset>
 </form>
 <?php echo $this->loadTemplate('items'); ?>

--- a/plugins/task/requests/src/Extension/Requests.php
+++ b/plugins/task/requests/src/Extension/Requests.php
@@ -126,7 +126,7 @@ final class Requests extends CMSPlugin implements SubscriberInterface
         $headers  = [];
 
         if ($auth && $authType && $authKey) {
-            $headers = [$authType => $authKey];
+            $headers = ['Authorization' => $authType . ' ' . $authKey];
         }
 
         try {

--- a/tests/Unit/Plugin/Task/Requests/Extension/RequestsPluginTest.php
+++ b/tests/Unit/Plugin/Task/Requests/Extension/RequestsPluginTest.php
@@ -239,7 +239,7 @@ class RequestsPluginTest extends UnitTestCase
         );
         $plugin->standardRoutineHandler($event);
 
-        $this->assertEquals(['basic' => '123'], $transport->headers);
+        $this->assertEquals(['Authorization' => 'basic 123'], $transport->headers);
     }
 
     /**


### PR DESCRIPTION
Pull Request for Issue #41318  .

### Summary of Changes

Change the language-string for correct table-head-title

### Testing Instructions

View in frontend a menue item of Menu_item_type "List Contacts in a Category"
index.php?option=com_contact&view=category
with "Table Headings" is "Show" in the "List Layouts"-Tab of this menue-item.
With this PR:
In the head of the table it is the word "Name" for the column of the names of the contacts 

### Actual result BEFORE applying this Pull Request

Bug:
In the head of the table it is the false word "Title" and not "Name" for the column of names of the contacts.

### Expected result AFTER applying this Pull Request

In the head of the table it is the word "Name" for the column of the names of the contacts


### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
